### PR TITLE
use proper update function if jQuery is present

### DIFF
--- a/wookmark.js
+++ b/wookmark.js
@@ -752,7 +752,7 @@
         if (!this.wookmarkInstance) {
           this.wookmarkInstance = new Wookmark(this[0], options || {});
         } else {
-          this.wookmarkInstance.update(options || {});
+          this.wookmarkInstance.updateOptions(options || {});
         }
       }
       return this;


### PR DESCRIPTION
Fixes TypeError 'undefined is not a function' when using with jQuery and calling .wookmark more than once on a jQuery object.